### PR TITLE
Only clear markdownCodeBlock syntax group if it exists

### DIFF
--- a/autoload/d2.vim
+++ b/autoload/d2.vim
@@ -129,7 +129,10 @@ endfunction
 
 function! d2#syntax_post() abort
   if index(b:included_syntaxes, 'markdown') != -1
-    syn clear markdownCodeBlock
+    if hlexists('markdownCodeBlock')
+      syn clear markdownCodeBlock
+    endif
+
     syn cluster d2BlockStringMarkdown add=@markdownBlock
   endif
 endfunction


### PR DESCRIPTION
I use `vim-markdown` for Markdown highlighting, which doesn't define a `markdownCodeBlock` syntax group. When opening a `.d2` file, it produces an error reporting that `markdownCodeBlock` doesn't exist.

This PR only clears the syntax group if it exists. It still adds the `@markdownBlock` cluster to the `@d2BlockStringMarkdown` cluster; it's up to the user to make sure `@markdownBlock` contains the necessary syntax groups from whatever syntax definition they're using, which is probably a reasonable compromise solution.

I can add something to the help file as well, if that would help.

Edit: Just realised this fixes #2 